### PR TITLE
fix upload command on Windows platform

### DIFF
--- a/polyaxon_cli/cli/upload.py
+++ b/polyaxon_cli/cli/upload.py
@@ -22,16 +22,15 @@ def upload(async):  # pylint:disable=assign-to-new-keyword
     project = ProjectManager.get_config_or_raise()
     files = IgnoreManager.get_unignored_file_paths()
     with create_tarfile(files, project.name) as file_path:
-        files, files_size = get_files_in_current_directory('repo', [file_path])
-        try:
-            PolyaxonClients().project.upload_repo(project.user, project.name, files, files_size, async)
-            PolyaxonClients().project.upload_repo(project.user,
-                                                  project.name,
-                                                  files,
-                                                  files_size,
-                                                  async)
-        except (PolyaxonHTTPError, PolyaxonShouldExitError) as e:
-            Printer.print_error('Could not upload code for project `{}`.'.format(project.name))
-            Printer.print_error('Error message `{}`.'.format(e))
-            sys.exit(1)
-        Printer.print_success('Files uploaded.')
+        with get_files_in_current_directory('repo', [file_path]) as (files, files_size):
+            try:
+                PolyaxonClients().project.upload_repo(project.user,
+                                                      project.name,
+                                                      files,
+                                                      files_size,
+                                                      async)
+            except (PolyaxonHTTPError, PolyaxonShouldExitError) as e:
+                Printer.print_error('Could not upload code for project `{}`.'.format(project.name))
+                Printer.print_error('Error message `{}`.'.format(e))
+                sys.exit(1)
+            Printer.print_success('Files uploaded.')

--- a/polyaxon_cli/cli/upload.py
+++ b/polyaxon_cli/cli/upload.py
@@ -21,16 +21,17 @@ def upload(async):  # pylint:disable=assign-to-new-keyword
     """Upload code of the current directory while respecting the .polyaxonignore file."""
     project = ProjectManager.get_config_or_raise()
     files = IgnoreManager.get_unignored_file_paths()
-    file_path = create_tarfile(files, project.name)
-    files, files_size = get_files_in_current_directory('repo', [file_path])
-    try:
-        PolyaxonClients().project.upload_repo(project.user,
-                                              project.name,
-                                              files,
-                                              files_size,
-                                              async)
-    except (PolyaxonHTTPError, PolyaxonShouldExitError) as e:
-        Printer.print_error('Could not upload code for project `{}`.'.format(project.name))
-        Printer.print_error('Error message `{}`.'.format(e))
-        sys.exit(1)
-    Printer.print_success('Files uploaded.')
+    with create_tarfile(files, project.name) as file_path:
+        files, files_size = get_files_in_current_directory('repo', [file_path])
+        try:
+            PolyaxonClients().project.upload_repo(project.user, project.name, files, files_size, async)
+            PolyaxonClients().project.upload_repo(project.user,
+                                                  project.name,
+                                                  files,
+                                                  files_size,
+                                                  async)
+        except (PolyaxonHTTPError, PolyaxonShouldExitError) as e:
+            Printer.print_error('Could not upload code for project `{}`.'.format(project.name))
+            Printer.print_error('Error message `{}`.'.format(e))
+            sys.exit(1)
+        Printer.print_success('Files uploaded.')

--- a/polyaxon_cli/utils/files.py
+++ b/polyaxon_cli/utils/files.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from polyaxon_cli.utils import constants
 
 
+@contextmanager
 def get_files_in_current_directory(file_type, file_paths):
     local_files = []
     total_file_size = 0
@@ -18,7 +19,11 @@ def get_files_in_current_directory(file_type, file_paths):
                             (unix_style_path(file_path), open(file_path, 'rb'), 'text/plain')))
         total_file_size += os.path.getsize(file_path)
 
-    return local_files, total_file_size
+    yield local_files, total_file_size
+
+    # close all files to avoid WindowsError: [Error 32]
+    for file in local_files:
+        file[1][1].close()
 
 
 def unix_style_path(path):

--- a/polyaxon_cli/utils/files.py
+++ b/polyaxon_cli/utils/files.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import tarfile
+import tempfile
+from contextlib import contextmanager
 
 from polyaxon_cli.utils import constants
 
@@ -35,11 +37,16 @@ def create_init_file(init_file_type):
     return True
 
 
+@contextmanager
 def create_tarfile(files, project_name):
     """Create a tar file based on the list of files passed"""
-    filename = "/tmp/{}.tar.gz".format(project_name)
+    fd, filename = tempfile.mkstemp(prefix="polyaxon_{}".format(project_name), suffix='.tar.gz')
     with tarfile.open(filename, "w:gz") as tar:
         for f in files:
             tar.add(f)
 
-    return filename
+    yield filename
+
+    # clear
+    os.close(fd)
+    os.remove(filename)

--- a/polyaxon_cli/utils/files.py
+++ b/polyaxon_cli/utils/files.py
@@ -22,8 +22,8 @@ def get_files_in_current_directory(file_type, file_paths):
     yield local_files, total_file_size
 
     # close all files to avoid WindowsError: [Error 32]
-    for file in local_files:
-        file[1][1].close()
+    for f in local_files:
+        f[1][1].close()
 
 
 def unix_style_path(path):

--- a/tests/test_utils/test_files.py
+++ b/tests/test_utils/test_files.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import tarfile
+from unittest import TestCase
+
+import os
+
+from polyaxon_cli.utils.files import create_tarfile
+
+
+class TestFiles(TestCase):
+    def test_create_tarfile(self):
+        files = ['tests/test_utils/__init__.py']
+        with create_tarfile(files, 'project_name') as tar_file_name:
+            assert os.path.exists(tar_file_name)
+            with tarfile.open(tar_file_name) as tf:
+                members = tf.getmembers()
+                assert set([m.name for m in members]) == set(files)
+        assert not os.path.exists(tar_file_name)
+

--- a/tests/test_utils/test_files.py
+++ b/tests/test_utils/test_files.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 
 import os
 
-from polyaxon_cli.utils.files import create_tarfile
+from polyaxon_cli.utils.files import create_tarfile, get_files_in_current_directory
 
 
 class TestFiles(TestCase):
@@ -17,3 +17,7 @@ class TestFiles(TestCase):
                 assert set([m.name for m in members]) == set(files)
         assert not os.path.exists(tar_file_name)
 
+    def test_get_files_in_current_directory(self):
+        file_paths = ['tests/test_utils/__init__.py']
+        with get_files_in_current_directory('repo', file_paths) as (files, files_size):
+            assert len(file_paths) == len(files)


### PR DESCRIPTION
Command `upload` create temp tar file under `/tmp` directory, which will fail on Windows platform. I use `tempfile` module to create temp file to support Windows and other platforms.