### PR TITLE
Allow the toggling of SSL verification for the cli tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ client/polyaxon/**/*.js
 client/polyaxon/**/*.js.map
 /examples/polyaxon-logs/
 lastfailed
+
+# IDE
+.vscode

--- a/polyaxon_cli/cli/config.py
+++ b/polyaxon_cli/cli/config.py
@@ -61,9 +61,10 @@ def get(keys):
 @click.option('--host', type=str, help='To set the server endpoint.')
 @click.option('--http_port', type=int, help='To set the http port.')
 @click.option('--ws_port', type=int, help='To set the stream port.')
-@click.option('--use_https', type=bool, help='To set the https.')
+@click.option('--use_https', type=bool, help='To set whether or not to use https.')
+@click.option('--verify_ssl', type=bool, help='To set whether or not to verify the SSL certificate.')
 @clean_outputs
-def set(verbose, host, http_port, ws_port, use_https):  # pylint:disable=redefined-builtin
+def set(verbose, host, http_port, ws_port, use_https, verify_ssl):  # pylint:disable=redefined-builtin
     """Set the global config values.
 
     Example:
@@ -89,6 +90,9 @@ def set(verbose, host, http_port, ws_port, use_https):  # pylint:disable=redefin
 
     if use_https is not None:
         _config.use_https = use_https
+
+    if verify_ssl is not None:
+        _config.verify_ssl = verify_ssl
 
     GlobalConfigManager.set_config(_config)
     Printer.print_success('Config was updated.')

--- a/polyaxon_cli/client/client.py
+++ b/polyaxon_cli/client/client.py
@@ -18,12 +18,14 @@ class PolyaxonClient(BasePolyaxonClient):
         http_port = GlobalConfigManager.get_value('http_port')
         ws_port = GlobalConfigManager.get_value('ws_port')
         use_https = GlobalConfigManager.get_value('use_https')
+        verify_ssl = GlobalConfigManager.get_value('verify_ssl')
         token = AuthConfigManager.get_value('token')
         super(PolyaxonClient, self).__init__(
             host=host,
             http_port=http_port,
             ws_port=ws_port,
             use_https=use_https,
+            verify_ssl=verify_ssl,
             token=token,
             schema_response=True,
             reraise=True,


### PR DESCRIPTION
This PR attempts to resolve https://github.com/polyaxon/polyaxon-cli/issues/14 by allowing verify_ssl to be a configurable option.