### PR TITLE
Allow verify_ssl to be turned on via the CLI

### DIFF
--- a/polyaxon_cli/cli/config.py
+++ b/polyaxon_cli/cli/config.py
@@ -97,7 +97,7 @@ def set(verbose,  # pylint:disable=redefined-builtin
     if use_https is not None:
         _config.use_https = use_https
 
-    if verify_ssl is False:
+    if verify_ssl is not None:
         _config.verify_ssl = verify_ssl
 
     GlobalConfigManager.set_config(_config)

--- a/polyaxon_cli/cli/config.py
+++ b/polyaxon_cli/cli/config.py
@@ -65,12 +65,7 @@ def get(keys):
 @click.option('--verify_ssl', type=bool,
               help='To set whether or not to verify the SSL certificate.')
 @clean_outputs
-def set(verbose,  # pylint:disable=redefined-builtin
-        host,
-        http_port,
-        ws_port,
-        use_https,
-        verify_ssl):
+def set(**kwargs):  # pylint:disable=redefined-builtin
     """Set the global config values.
 
     Example:
@@ -82,23 +77,9 @@ def set(verbose,  # pylint:disable=redefined-builtin
     """
     _config = GlobalConfigManager.get_config_or_default()
 
-    if verbose is not None:
-        _config.verbose = verbose
-
-    if host is not None:
-        _config.host = host
-
-    if http_port is not None:
-        _config.http_port = http_port
-
-    if ws_port is not None:
-        _config.ws_port = ws_port
-
-    if use_https is not None:
-        _config.use_https = use_https
-
-    if verify_ssl is not None:
-        _config.verify_ssl = verify_ssl
+    for key, value in kwargs.items():
+        if value is not None:
+            setattr(_config, key, value)
 
     GlobalConfigManager.set_config(_config)
     Printer.print_success('Config was updated.')


### PR DESCRIPTION
This fixes a bug that prevented the CLI from setting `config.verify_ssl` to `true`.

This means that `polyaxon config set --verify_ssl=true` previously didn't change the config at all.