### PR TITLE
Fix unit tests on CI

### DIFF
--- a/polyaxon_cli/cli/run.py
+++ b/polyaxon_cli/cli/run.py
@@ -19,7 +19,7 @@ from polyaxon_cli.managers.experiment import ExperimentManager
 from polyaxon_cli.managers.experiment_group import GroupManager
 from polyaxon_cli.managers.job import JobManager
 from polyaxon_cli.schemas.experiment import ExperimentConfig
-from polyaxon_cli.schemas.group import ExperimentGroupConfig
+from polyaxon_cli.schemas.group import GroupConfig
 from polyaxon_cli.schemas.job import JobConfig
 from polyaxon_cli.schemas.polyaxonfile import PolyaxonFile
 from polyaxon_cli.utils import cache
@@ -138,7 +138,7 @@ def run(ctx, project, file, name, tags, description, ttl, u, l):  # pylint:disab
         click.echo('Creating an experiment group with the following definition:')
         experiments_def = specification.experiments_def
         get_group_experiments_info(**experiments_def)
-        experiment_group = ExperimentGroupConfig(
+        experiment_group = GroupConfig(
             name=name,
             description=description,
             tags=tags,

--- a/polyaxon_cli/managers/experiment_group.py
+++ b/polyaxon_cli/managers/experiment_group.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 import sys
 
 from polyaxon_cli.managers.base import BaseConfigManager
-from polyaxon_cli.schemas.group import ExperimentGroupConfig
+from polyaxon_cli.schemas.group import GroupConfig
 from polyaxon_cli.utils.formatting import Printer
 
 
@@ -14,7 +14,7 @@ class GroupManager(BaseConfigManager):
     IS_GLOBAL = False
     IS_POLYAXON_DIR = True
     CONFIG_FILE_NAME = '.polyaxongroup'
-    CONFIG = ExperimentGroupConfig
+    CONFIG = GroupConfig
 
     @classmethod
     def get_config_or_raise(cls):

--- a/polyaxon_cli/schemas/group.py
+++ b/polyaxon_cli/schemas/group.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function
 
-from polyaxon_schemas.api.project import ExperimentGroupConfig  # noqa
+from polyaxon_schemas.api.group import GroupConfig  # noqa

--- a/requirements/requirements-base.txt
+++ b/requirements/requirements-base.txt
@@ -1,4 +1,5 @@
 click==6.7
+clint==0.5.1
 pathlib==1.0.1
 raven==6.7.0
 tabulate==0.8.2

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(name='polyaxon-cli',
       ],
       install_requires=[
           "click==6.7",
+          "clint==0.5.1",
           "pathlib==1.0.1",
           "polyaxon-client==0.4.4",
           "polyaxon-deploy==0.4.4",

--- a/tests/test_managers/test_experiment_group.py
+++ b/tests/test_managers/test_experiment_group.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function
 from unittest import TestCase
 
 from polyaxon_cli.managers.experiment_group import GroupManager
-from polyaxon_cli.schemas.group import ExperimentGroupConfig
+from polyaxon_cli.schemas.group import GroupConfig
 
 
 class TestGroupManager(TestCase):
@@ -12,4 +12,4 @@ class TestGroupManager(TestCase):
         assert GroupManager.IS_GLOBAL is False
         assert GroupManager.IS_POLYAXON_DIR is True
         assert GroupManager.CONFIG_FILE_NAME == '.polyaxongroup'
-        assert GroupManager.CONFIG == ExperimentGroupConfig
+        assert GroupManager.CONFIG == GroupConfig


### PR DESCRIPTION
These are a few issues I found while checking out the CI failures in #23.

This doesn't fix `prospector` but makes the unit tests pass on CI